### PR TITLE
Prod image bug fix 

### DIFF
--- a/tempero/src/utils/ImageURL.tsx
+++ b/tempero/src/utils/ImageURL.tsx
@@ -1,40 +1,26 @@
-import { isStaging, supabase } from "../config/supabaseClient";
+import { supabase } from "../config/supabaseClient";
 
 
 export function recipeImageUrl(
-  path?: string | null,
-  width: number = 800
+  path?: string | null
 ): string | undefined {
   if (!path) return undefined;
 
   const { data } = supabase.storage
     .from("images")
-    .getPublicUrl(path, !isStaging ? {
-      transform: {
-        width,
-        quality: 80,
-        format: "origin",
-      },
-    } : {});
+    .getPublicUrl(path);
 
   return data.publicUrl;
 }
 
 export function profileImageUrl(
-  path?: string | null,
-  width: number = 300
+  path?: string | null
 ): string | undefined {
   if (!path) return undefined;
 
   const { data } = supabase.storage
     .from("images")
-    .getPublicUrl(path, !isStaging ? {
-      transform: {
-        width,
-        quality: 80,
-        format: "origin",
-      },
-    } : {});
+    .getPublicUrl(path);
 
   return data.publicUrl;
 }


### PR DESCRIPTION
Image transformations are not supported on the free tier of Supabase which was causing the images on the prod site to not appear. 